### PR TITLE
fix(formatter): remove stray space breaking mochi profile links

### DIFF
--- a/packages/mochi-formatter/src/ui/render.ts
+++ b/packages/mochi-formatter/src/ui/render.ts
@@ -491,13 +491,13 @@ function mochi(p?: Profile | null, on = Platform.Mochi): UsernameFmt {
     return {
       value: `${on === Platform.Discord ? "\\" : ""}${emojiPrefix}${
         emojiPrefix ? " " : ""
-      }[${textPrefix}${p.profile_name || p.id}](${HOMEPAGE} /profile/${p.id})`,
+      }[${textPrefix}${p.profile_name || p.id}](${HOMEPAGE}/profile/${p.id})`,
       plain: `${on === Platform.Discord ? "\\" : ""}${emojiPrefix}${
         emojiPrefix ? " " : ""
-      }${textPrefix}${p.profile_name || p.id} `,
+      }${textPrefix}${p.profile_name || p.id}`,
       platform: Platform.Mochi,
       id: p.id,
-      url: `${HOMEPAGE} /profile/${p.id} `,
+      url: `${HOMEPAGE}/profile/${p.id}`,
     };
   } catch (e) {
     return { plain: "", value: "", id: "", url: "" };

--- a/packages/mochi-id/src/index.ts
+++ b/packages/mochi-id/src/index.ts
@@ -448,13 +448,13 @@ function mochi(p?: Profile | null, on = Platform.Mochi): UsernameFmt {
     return {
       value: `${on === Platform.Discord ? "\\" : ""}${emojiPrefix}${
         emojiPrefix ? " " : ""
-      }[${textPrefix}${p.profile_name || p.id}](${HOMEPAGE} /profile/${p.id})`,
+      }[${textPrefix}${p.profile_name || p.id}](${HOMEPAGE}/profile/${p.id})`,
       plain: `${on === Platform.Discord ? "\\" : ""}${emojiPrefix}${
         emojiPrefix ? " " : ""
-      }${textPrefix}${p.profile_name || p.id} `,
+      }${textPrefix}${p.profile_name || p.id}`,
       platform: Platform.Mochi,
       id: p.id,
-      url: `${HOMEPAGE} /profile/${p.id} `,
+      url: `${HOMEPAGE}/profile/${p.id}`,
     };
   } catch (e) {
     return { plain: "", value: "", id: "", url: "" };


### PR DESCRIPTION
## What

Remove a stray space inside the profile URL of masked links built by the `mochi()` profile renderer (mochi-formatter + same copy-paste bug in mochi-id).

## Why

Discord refuses to parse a masked link whose URL contains a space, so transaction rows in the balance embed fell back to raw markdown text:

```
9d ago | cce99 | +2 ICY from [mochi:Auto Rewards](https://mochi.gg /profile/121327584257067)
```

while vault/app profiles (different renderers, no space) rendered fine.

## How

`${HOMEPAGE} /profile/${p.id}` -> `${HOMEPAGE}/profile/${p.id}` in the `value` and `url` fields, plus dropping trailing spaces in `plain`/`url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
