### PR TITLE
chore(formatter): bump to 20.0.12 and add manual publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,32 @@
+name: Publish package
+
+# Manual publish of a single workspace package to npm. The changesets-based
+# `pnpm release` flow predates this and published every drifted package at
+# once; this dispatch publishes only the package you name.
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Workspace package to publish (e.g. @consolelabs/mochi-formatter)"
+        required: true
+        default: "@consolelabs/mochi-formatter"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 8.6.10
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm --filter "$PACKAGE" publish --access public --no-git-checks
+        env:
+          PACKAGE: ${{ github.event.inputs.package }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/mochi-formatter/package.json
+++ b/packages/mochi-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@consolelabs/mochi-formatter",
-  "version": "20.0.9",
+  "version": "20.0.12",
   "description": "Mochi Formatter for profiles, numbers, texts",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## What
- Bump `@consolelabs/mochi-formatter` 20.0.9 -> 20.0.12 (npm latest is 20.0.11; repo field had drifted).
- Add a `workflow_dispatch` publish workflow for a single workspace package, using the org `NPM_TOKEN` (granted to this repo today).

## Why
Ships the profile-link fix (#47) to npm so mochi-discord picks it up: its Docker build runs `pnpm up '@consolelabs/*' --latest`, so publish + prod rebuild is the whole wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)